### PR TITLE
add missing end error_handlers.each

### DIFF
--- a/lib/sidekiq/clockwork.rb
+++ b/lib/sidekiq/clockwork.rb
@@ -44,9 +44,9 @@ module Sidekiq
     def run_error_handlers(error)
       error_handlers.each do |handler|
         handler.call(error)
+      end 
       rescue StandardError => handler_error
         $stderr << error_message(handler_error, "Error handler raised exception. ")
-      end
     end
 
     def error_message(error, prefix = nil)


### PR DESCRIPTION
It looks like there was a missing or misplaced end. 

If you wanted to loop through all the handlers and ensure they each had a chance, I think you would have to use begin. 